### PR TITLE
Expose GenesisCovenantGroup to WASM SDK

### DIFF
--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use js_sys::Object;
+use kaspa_math::wasm::JsValueExtension;
 use kaspa_utils::hex::ToHex;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use kaspa_utils::{serde_bytes, serde_bytes_fixed_ref};
@@ -182,19 +183,82 @@ impl CovenantBinding {
     }
 }
 
+#[wasm_bindgen]
+extern "C" {
+    /// WASM (TypeScript) type representing an array of [`GenesisCovenantGroup`] objects: `GenesisCovenantGroup[]`.
+    ///
+    /// @category Consensus
+    #[wasm_bindgen(extends = js_sys::Array, typescript_type = "GenesisCovenantGroup[]")]
+    pub type GenesisCovenantGroupArrayT;
+}
+
 /// A genesis covenant group for bulk covenant binding population.
 ///
 /// All listed outputs are bound to the same covenant id, derived from the
 /// authorizing input outpoint and this exact ordered output list.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, CastFromJs)]
+#[serde(rename_all = "camelCase")]
+#[wasm_bindgen(inspectable)]
 pub struct GenesisCovenantGroup {
     pub authorizing_input: u16,
+    #[wasm_bindgen(skip)]
     pub outputs: Vec<u32>,
 }
 
 impl GenesisCovenantGroup {
     pub fn new(authorizing_input: u16, outputs: Vec<u32>) -> Self {
         Self { authorizing_input, outputs }
+    }
+}
+
+#[wasm_bindgen]
+impl GenesisCovenantGroup {
+    #[wasm_bindgen(constructor)]
+    pub fn ctor(authorizing_input: u16, outputs: Vec<u32>) -> Self {
+        Self { authorizing_input, outputs }
+    }
+
+    #[wasm_bindgen(setter = outputs)]
+    pub fn set_outputs(&mut self, outputs: Vec<u32>) {
+        self.outputs = outputs;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn outputs(&self) -> Vec<u32> {
+        self.outputs.clone()
+    }
+
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_js_object(&self) -> Result<Object, workflow_wasm::error::Error> {
+        let obj = Object::new();
+        obj.set("authorizingInput", &self.authorizing_input.into())?;
+        obj.set("outputs", &js_sys::Array::from_iter(self.outputs.iter().map(|&v| JsValue::from(v))))?;
+        Ok(obj)
+    }
+
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn js_to_string(&self) -> Result<js_sys::JsString, workflow_wasm::error::Error> {
+        Ok(js_sys::JSON::stringify(&self.to_js_object()?.into())?)
+    }
+}
+
+impl TryCastFromJs for GenesisCovenantGroup {
+    type Error = CastErr;
+
+    fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
+    where
+        R: AsRef<JsValue> + 'a,
+    {
+        Self::resolve(value, || {
+            let Some(object) = Object::try_from(value.as_ref()) else { return Err(CastErr::NotAnObject) };
+            let authorizing_input = object.get_u16("authorizingInput")?;
+            let outputs = object
+                .get_vec("outputs")?
+                .iter()
+                .map(|idx| idx.try_as_u32())
+                .collect::<Result<Vec<u32>, workflow_wasm::error::Error>>()?;
+            Ok(Self { authorizing_input, outputs })
+        })
     }
 }
 


### PR DESCRIPTION
All wiring to expose `GenesisCovenantGroup ` to WASM SDK. 

Notes & callouts:

- All of the below is done in `consensus/core/src/tx.rs` given there's already other WASM related code here.
- Field `outputs` has `#[wasm_bindgen(skip)]` because `Vec<u32>` does not implement copy, `#[wasm_bindgen]` requires all fields to impl copy. [skip](https://wasm-bindgen.github.io/wasm-bindgen/reference/attributes/on-rust-exports/skip.html#skip) prevents field `outputs` from being exposed to JS via getter/setter methods.
- Because of skip on `outputs` field, getter/setter for `outputs` are implemented manually via functions.
- Because of skip on `outputs` field, `to_js_object` and `js_to_string` functions are implemented to override default from [`inspectable`](https://wasm-bindgen.github.io/wasm-bindgen/reference/attributes/on-rust-exports/inspectable.html#inspectable).
- Added `impl TryCastFromJs for GenesisCovenantGroup`.
- Added `GenesisCovenantGroupArrayT` just before `GenesisCovenantGroup` struct. Maybe feels odd for it to be in this file but looks like convention throughout rest of the codebase is that the `ArrayT` type be defined just before the given struct. So maintained that here.

Tried to keep naming conventions, patterns, comment structure, etc. consistent with other WASM related code throughout the codebase - most of  this is inspired by/modeled after existing WASM code.