### PR TITLE
Additional GenesisCovenantGroup WASM related wiring

### DIFF
--- a/consensus/core/src/errors/tx.rs
+++ b/consensus/core/src/errors/tx.rs
@@ -124,6 +124,14 @@ pub enum PopulateGenesisCovenantsError {
     CovenantAlreadyPopulated(u32),
     #[error("The genesis covenant group array is invalid")]
     InvalidGenesisCovenantGroupArray,
+    #[error("{0}")]
+    WASM(String),
+}
+
+impl From<workflow_wasm::error::Error> for PopulateGenesisCovenantsError {
+    fn from(e: workflow_wasm::error::Error) -> Self {
+        PopulateGenesisCovenantsError::WASM(e.to_string())
+    }
 }
 
 pub type TxResult<T> = std::result::Result<T, TxRuleError>;

--- a/consensus/core/src/errors/tx.rs
+++ b/consensus/core/src/errors/tx.rs
@@ -122,6 +122,8 @@ pub enum PopulateGenesisCovenantsError {
     OutputsNotDisjoint(u32),
     #[error("output index {0} covenant field is already populated")]
     CovenantAlreadyPopulated(u32),
+    #[error("The genesis covenant group array is invalid")]
+    InvalidGenesisCovenantGroupArray,
 }
 
 pub type TxResult<T> = std::result::Result<T, TxRuleError>;

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -193,7 +193,7 @@ extern "C" {
 }
 
 impl TryFrom<&GenesisCovenantGroupArrayT> for Vec<GenesisCovenantGroup> {
-    type Error = CastErr;
+    type Error = PopulateGenesisCovenantsError;
     fn try_from(value: &GenesisCovenantGroupArrayT) -> Result<Self, Self::Error> {
         if value.is_array() {
             let array = js_sys::Array::from(value);
@@ -201,7 +201,7 @@ impl TryFrom<&GenesisCovenantGroupArrayT> for Vec<GenesisCovenantGroup> {
                 array.iter().map(GenesisCovenantGroup::try_owned_from).collect::<Result<Vec<_>, CastErr>>()?;
             Ok(groups)
         } else {
-            Err(CastErr::WrongType("Must be an array".to_string()))
+            Err(PopulateGenesisCovenantsError::InvalidGenesisCovenantGroupArray)
         }
     }
 }

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -192,6 +192,20 @@ extern "C" {
     pub type GenesisCovenantGroupArrayT;
 }
 
+impl TryFrom<&GenesisCovenantGroupArrayT> for Vec<GenesisCovenantGroup> {
+    type Error = workflow_wasm::error::Error;
+    fn try_from(value: &GenesisCovenantGroupArrayT) -> Result<Self, Self::Error> {
+        if value.is_array() {
+            let array = js_sys::Array::from(value);
+            let groups =
+                array.iter().map(GenesisCovenantGroup::try_owned_from).collect::<Result<Vec<_>, workflow_wasm::error::Error>>()?;
+            Ok(groups)
+        } else {
+            Err(workflow_wasm::error::Error::WrongType("Must be an array".to_string()))
+        }
+    }
+}
+
 /// A genesis covenant group for bulk covenant binding population.
 ///
 /// All listed outputs are bound to the same covenant id, derived from the

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -193,15 +193,15 @@ extern "C" {
 }
 
 impl TryFrom<&GenesisCovenantGroupArrayT> for Vec<GenesisCovenantGroup> {
-    type Error = workflow_wasm::error::Error;
+    type Error = CastErr;
     fn try_from(value: &GenesisCovenantGroupArrayT) -> Result<Self, Self::Error> {
         if value.is_array() {
             let array = js_sys::Array::from(value);
             let groups =
-                array.iter().map(GenesisCovenantGroup::try_owned_from).collect::<Result<Vec<_>, workflow_wasm::error::Error>>()?;
+                array.iter().map(GenesisCovenantGroup::try_owned_from).collect::<Result<Vec<_>, CastErr>>()?;
             Ok(groups)
         } else {
-            Err(workflow_wasm::error::Error::WrongType("Must be an array".to_string()))
+            Err(CastErr::WrongType("Must be an array".to_string()))
         }
     }
 }
@@ -243,7 +243,7 @@ impl GenesisCovenantGroup {
     }
 
     #[wasm_bindgen(js_name = "toJSON")]
-    pub fn to_js_object(&self) -> Result<Object, workflow_wasm::error::Error> {
+    pub fn to_js_object(&self) -> Result<Object, CastErr> {
         let obj = Object::new();
         obj.set("authorizingInput", &self.authorizing_input.into())?;
         obj.set("outputs", &js_sys::Array::from_iter(self.outputs.iter().map(|&v| JsValue::from(v))))?;
@@ -251,7 +251,7 @@ impl GenesisCovenantGroup {
     }
 
     #[wasm_bindgen(js_name = "toString")]
-    pub fn js_to_string(&self) -> Result<js_sys::JsString, workflow_wasm::error::Error> {
+    pub fn js_to_string(&self) -> Result<js_sys::JsString, CastErr> {
         Ok(js_sys::JSON::stringify(&self.to_js_object()?.into())?)
     }
 }
@@ -270,7 +270,7 @@ impl TryCastFromJs for GenesisCovenantGroup {
                 .get_vec("outputs")?
                 .iter()
                 .map(|idx| idx.try_as_u32())
-                .collect::<Result<Vec<u32>, workflow_wasm::error::Error>>()?;
+                .collect::<Result<Vec<u32>, CastErr>>()?;
             Ok(Self { authorizing_input, outputs })
         })
     }

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -196,10 +196,11 @@ impl TryFrom<&GenesisCovenantGroupArrayT> for Vec<GenesisCovenantGroup> {
     type Error = PopulateGenesisCovenantsError;
     fn try_from(value: &GenesisCovenantGroupArrayT) -> Result<Self, Self::Error> {
         if value.is_array() {
-            let array = js_sys::Array::from(value);
-            let groups =
-                array.iter().map(GenesisCovenantGroup::try_owned_from).collect::<Result<Vec<_>, CastErr>>()?;
-            Ok(groups)
+            value
+                .iter()
+                .map(GenesisCovenantGroup::try_owned_from)
+                .map(|r| r.map_err(PopulateGenesisCovenantsError::from))
+                .collect::<Result<Vec<GenesisCovenantGroup>, PopulateGenesisCovenantsError>>()
         } else {
             Err(PopulateGenesisCovenantsError::InvalidGenesisCovenantGroupArray)
         }
@@ -266,11 +267,7 @@ impl TryCastFromJs for GenesisCovenantGroup {
         Self::resolve(value, || {
             let Some(object) = Object::try_from(value.as_ref()) else { return Err(CastErr::NotAnObject) };
             let authorizing_input = object.get_u16("authorizingInput")?;
-            let outputs = object
-                .get_vec("outputs")?
-                .iter()
-                .map(|idx| idx.try_as_u32())
-                .collect::<Result<Vec<u32>, CastErr>>()?;
+            let outputs = object.get_vec("outputs")?.iter().map(|idx| idx.try_as_u32()).collect::<Result<Vec<u32>, CastErr>>()?;
             Ok(Self { authorizing_input, outputs })
         })
     }


### PR DESCRIPTION
- Add error variants `InvalidGenesisCovenantGroupArray` and `WASM` to error `PopulateGenesisCovenantsError`. These variants mirror similar patterns present for WASM ArrayT-type handling and error conversions elsewhere in the codebase (reference: `AddressOrStringArrayT`, `AddressError`, `impl TryFrom<AddressOrStringArrayT> for Vec<Address>`, `impl From<workflow_wasm::error::Error> for AddressError`).
- Added `impl TryFrom<&GenesisCovenantGroupArrayT> for Vec<GenesisCovenantGroup>`
- Added `impl From<workflow_wasm::error::Error> for PopulateGenesisCovenantsError`
- Change from `workflow_wasm::error::Error` to `CastErr` (which is a type alias for `workflow_wasm::error::Error` already defined in the same file) in `/consensus/core/src/tx.rs` where possible.