### PR TITLE
Consensus client changes to support populate_genesis_covenants

### DIFF
--- a/consensus/client/src/error.rs
+++ b/consensus/client/src/error.rs
@@ -53,6 +53,9 @@ pub enum Error {
 
     #[error("Transaction input is missing UTXO entry")]
     MissingUtxoEntry,
+
+    #[error(transparent)]
+    PopulateGenesisCovenants(#[from] kaspa_consensus_core::errors::tx::PopulateGenesisCovenantsError),
 }
 
 impl Error {

--- a/consensus/client/src/output.rs
+++ b/consensus/client/src/output.rs
@@ -144,7 +144,7 @@ impl From<&cctx::TransactionOutput> for TransactionOutput {
 impl From<&TransactionOutput> for cctx::TransactionOutput {
     fn from(output: &TransactionOutput) -> Self {
         let inner = output.inner();
-        cctx::TransactionOutput::new(inner.value, inner.script_public_key.clone())
+        cctx::TransactionOutput::with_covenant(inner.value, inner.script_public_key.clone(), inner.covenant)
     }
 }
 

--- a/consensus/client/src/output.rs
+++ b/consensus/client/src/output.rs
@@ -111,6 +111,16 @@ impl TransactionOutput {
     pub fn set_script_public_key(&self, v: &ScriptPublicKey) {
         self.inner().script_public_key = v.clone();
     }
+
+    #[wasm_bindgen(getter, js_name = covenant)]
+    pub fn get_covenant(&self) -> Option<cctx::CovenantBinding> {
+        self.inner().covenant
+    }
+
+    #[wasm_bindgen(setter, js_name = covenant)]
+    pub fn set_covenant(&self, v: cctx::CovenantBinding) {
+        self.inner().covenant = Some(v)
+    }
 }
 
 impl AsRef<TransactionOutput> for TransactionOutput {

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -277,6 +277,7 @@ impl Transaction {
         self.inner().mass = v;
     }
 
+    #[wasm_bindgen(js_name = populateGenesisCovenants)]
     pub fn populate_genesis_covenants(&self, groups: &GenesisCovenantGroupArrayT) -> Result<()> {
         let groups: Vec<GenesisCovenantGroup> = groups.try_into()?;
         let mut tx: cctx::Transaction = self.into();

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -15,7 +15,7 @@ use ahash::AHashMap;
 use kaspa_consensus_core::network::NetworkType;
 use kaspa_consensus_core::network::NetworkTypeT;
 use kaspa_consensus_core::subnets::{self, SubnetworkId};
-use kaspa_consensus_core::tx::UtxoEntry;
+use kaspa_consensus_core::tx::{GenesisCovenantGroup, GenesisCovenantGroupArrayT, UtxoEntry};
 use kaspa_txscript::extract_script_pub_key_address;
 use kaspa_utils::hex::*;
 
@@ -275,6 +275,14 @@ impl Transaction {
     #[wasm_bindgen(setter = mass)]
     pub fn set_mass(&self, v: u64) {
         self.inner().mass = v;
+    }
+
+    pub fn populate_genesis_covenants(&self, groups: &GenesisCovenantGroupArrayT) -> Result<()> {
+        let groups: Vec<GenesisCovenantGroup> = groups.try_into()?;
+        let mut tx: cctx::Transaction = self.into();
+        tx.populate_genesis_covenants(groups.as_slice())?;
+        self.inner().outputs = tx.outputs.iter().map(TransactionOutput::from).collect::<Vec<TransactionOutput>>();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Add fn `populate_genesis_covenants()` to consensus client Transaction
- Add getter/setter for covenant field to consensus client TransactionOutput
- Add error variant `PopulateGenesisCovenants` to consensus client error