### PR TITLE
Add native/non-WASM populate_genesis_covenants fn to client Transaction

### DIFF
--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -279,11 +279,9 @@ impl Transaction {
     }
 
     #[wasm_bindgen(js_name = populateGenesisCovenants)]
-    pub fn populate_genesis_covenants(&self, groups: &GenesisCovenantGroupArrayT) -> Result<()> {
+    pub fn js_populate_genesis_covenants(&self, groups: &GenesisCovenantGroupArrayT) -> Result<()> {
         let groups: Vec<GenesisCovenantGroup> = groups.try_into()?;
-        let mut tx: cctx::Transaction = self.into();
-        tx.populate_genesis_covenants(groups.as_slice())?;
-        self.inner().outputs = tx.outputs.iter().map(TransactionOutput::from).collect::<Vec<TransactionOutput>>();
+        self.populate_genesis_covenants(&groups)?;
         Ok(())
     }
 }
@@ -468,6 +466,13 @@ impl Transaction {
 
     pub fn payload_len(&self) -> usize {
         self.inner().payload.len()
+    }
+
+    pub fn populate_genesis_covenants(&self, groups: &[GenesisCovenantGroup]) -> Result<()> {
+        let mut tx: cctx::Transaction = self.into();
+        tx.populate_genesis_covenants(groups)?;
+        self.inner().outputs = tx.outputs.iter().map(TransactionOutput::from).collect::<Vec<TransactionOutput>>();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
**Changes**:
- Add `populate_genesis_covenants()` function to native/non-WASM impl block on consensus client `Transaction`.
- Add `js_` prefix to existing WASM version of the function to address duplicate names.
- Change `js_populate_genesis_covenants()` to call native `populate_genesis_covenants()`, effectively a wrapper.

**Why:** I believe this function should be available to Rust consumers of consensus client `Transaction`. Selfishly, a native Rust version is needed for Python bindings.


