### PR TITLE
Move CovenantBinding WASM glue & clean up tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ name = "kaspa-consensus-client"
 version = "1.1.0"
 dependencies = [
  "ahash",
+ "borsh",
  "cfg-if 1.0.0",
  "faster-hex 0.9.0",
  "hex",

--- a/consensus/client/Cargo.toml
+++ b/consensus/client/Cargo.toml
@@ -22,6 +22,7 @@ kaspa-utils.workspace = true
 kaspa-wasm-core.workspace = true
 
 ahash.workspace = true
+borsh.workspace = true
 cfg-if.workspace = true
 faster-hex.workspace = true
 hex.workspace = true

--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -6,9 +6,101 @@
 
 use crate::imports::*;
 use crate::result::Result as ClientResult;
+use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_consensus_core::errors::tx::PopulateGenesisCovenantsError;
-use kaspa_consensus_core::tx::GenesisCovenantGroup as CoreGenesisCovenantGroup;
+use kaspa_consensus_core::tx::{CovenantBinding as CoreCovenantBinding, GenesisCovenantGroup as CoreGenesisCovenantGroup};
+use kaspa_hashes::Hash;
 use kaspa_wasm_core::types::NumberArray;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_COVENANT_BINDING: &'static str = r#"
+/**
+ * A covenant binding binds a transaction output to the covenant and input authorizing its creation.
+ *
+ * @category Consensus
+ */
+export interface ICovenantBinding {
+    authorizingInput: number;
+    covenantId: HexString;
+}
+"#;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy, BorshSerialize, BorshDeserialize, CastFromJs)]
+#[serde(rename_all = "camelCase")]
+#[wasm_bindgen(inspectable)]
+pub struct CovenantBinding {
+    inner: CoreCovenantBinding,
+}
+
+// impl CovenantBinding {
+//     pub fn inner(&self) -> &CoreCovenantBinding {
+//         &self.inner
+//     }
+// }
+
+#[wasm_bindgen]
+impl CovenantBinding {
+    #[wasm_bindgen(constructor)]
+    pub fn new(authorizing_input: u16, covenant_id: Hash) -> Self {
+        Self { inner: CoreCovenantBinding::new(authorizing_input, covenant_id) }
+    }
+
+    #[wasm_bindgen(setter, js_name = authorizingInput)]
+    pub fn set_authorizing_input(&mut self, v: u16) {
+        self.inner.authorizing_input = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = authorizingInput)]
+    pub fn get_authorizing_input(&self) -> u16 {
+        self.inner.authorizing_input
+    }
+
+    #[wasm_bindgen(setter, js_name = covenantId)]
+    pub fn set_covenant_id(&mut self, v: Hash) {
+        self.inner.covenant_id = v;
+    }
+
+    #[wasm_bindgen(getter, js_name = covenantId)]
+    pub fn get_covenant_id(&self) -> Hash {
+        self.inner.covenant_id
+    }
+
+    #[wasm_bindgen(js_name = toJSON)]
+    pub fn to_js_object(&self) -> Result<Object, workflow_wasm::error::Error> {
+        let obj = Object::new();
+        obj.set("authorizingInput", &self.get_authorizing_input().into())?;
+        obj.set("covenantId", &self.get_covenant_id().to_string().into())?;
+        Ok(obj)
+    }
+}
+
+impl From<CoreCovenantBinding> for CovenantBinding {
+    fn from(value: CoreCovenantBinding) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl From<CovenantBinding> for CoreCovenantBinding {
+    fn from(value: CovenantBinding) -> Self {
+        value.inner
+    }
+}
+
+impl TryCastFromJs for CovenantBinding {
+    type Error = workflow_wasm::error::Error;
+
+    fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
+    where
+        R: AsRef<JsValue> + 'a,
+    {
+        Self::resolve(value, || {
+            let Some(object) = Object::try_from(value.as_ref()) else { return Err(Self::Error::NotAnObject) };
+            let authorizing_input = object.get_u16("authorizingInput")?;
+            let covenant_id = object.get_value("covenantId")?.try_into_owned()?;
+            Ok(Self { inner: CoreCovenantBinding::new(authorizing_input, covenant_id) })
+        })
+    }
+}
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_GENESIS_COVENANT_GROUP: &'static str = r#"

--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -11,6 +11,7 @@ use kaspa_consensus_core::errors::tx::PopulateGenesisCovenantsError;
 use kaspa_consensus_core::tx::{CovenantBinding as CoreCovenantBinding, GenesisCovenantGroup as CoreGenesisCovenantGroup};
 use kaspa_hashes::Hash;
 use kaspa_wasm_core::types::NumberArray;
+use workflow_wasm::error::Error as WasmError;
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_COVENANT_BINDING: &'static str = r#"
@@ -31,12 +32,6 @@ export interface ICovenantBinding {
 pub struct CovenantBinding {
     inner: CoreCovenantBinding,
 }
-
-// impl CovenantBinding {
-//     pub fn inner(&self) -> &CoreCovenantBinding {
-//         &self.inner
-//     }
-// }
 
 #[wasm_bindgen]
 impl CovenantBinding {
@@ -66,7 +61,7 @@ impl CovenantBinding {
     }
 
     #[wasm_bindgen(js_name = toJSON)]
-    pub fn to_js_object(&self) -> Result<Object, workflow_wasm::error::Error> {
+    pub fn to_js_object(&self) -> Result<Object, WasmError> {
         let obj = Object::new();
         obj.set("authorizingInput", &self.get_authorizing_input().into())?;
         obj.set("covenantId", &self.get_covenant_id().to_string().into())?;
@@ -87,7 +82,7 @@ impl From<CovenantBinding> for CoreCovenantBinding {
 }
 
 impl TryCastFromJs for CovenantBinding {
-    type Error = workflow_wasm::error::Error;
+    type Error = WasmError;
 
     fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
     where
@@ -198,7 +193,7 @@ impl GenesisCovenantGroup {
     }
 
     #[wasm_bindgen(js_name = "toJSON")]
-    pub fn to_js_object(&self) -> Result<Object, workflow_wasm::error::Error> {
+    pub fn to_js_object(&self) -> Result<Object, WasmError> {
         let obj = Object::new();
         obj.set("authorizingInput", &self.inner.authorizing_input.into())?;
         obj.set("outputs", &js_sys::Array::from_iter(self.inner.outputs.iter().map(|&v| JsValue::from(v))))?;
@@ -206,13 +201,13 @@ impl GenesisCovenantGroup {
     }
 
     #[wasm_bindgen(js_name = "toString")]
-    pub fn js_to_string(&self) -> Result<js_sys::JsString, workflow_wasm::error::Error> {
+    pub fn js_to_string(&self) -> Result<js_sys::JsString, WasmError> {
         Ok(js_sys::JSON::stringify(&self.to_js_object()?.into())?)
     }
 }
 
 impl TryCastFromJs for GenesisCovenantGroup {
-    type Error = workflow_wasm::error::Error;
+    type Error = WasmError;
 
     fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
     where
@@ -220,11 +215,11 @@ impl TryCastFromJs for GenesisCovenantGroup {
     {
         Self::resolve(value, || {
             let Some(object) = Object::try_from(value.as_ref()) else {
-                return Err(workflow_wasm::error::Error::NotAnObject);
+                return Err(Self::Error::NotAnObject);
             };
             let authorizing_input = object.get_u16("authorizingInput")?;
-            let outputs: Vec<u32> = serde_wasm_bindgen::from_value(object.get_value("outputs")?)
-                .map_err(|err| workflow_wasm::error::Error::from(JsValue::from(err)))?;
+            let outputs: Vec<u32> =
+                serde_wasm_bindgen::from_value(object.get_value("outputs")?).map_err(|err| Self::Error::from(JsValue::from(err)))?;
             Ok(Self { inner: CoreGenesisCovenantGroup::new(authorizing_input, outputs) })
         })
     }

--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -228,6 +228,8 @@ impl TryCastFromJs for GenesisCovenantGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kaspa_hashes::HASH_SIZE;
+    use std::str::FromStr;
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -388,5 +390,70 @@ mod tests {
         let typed: &GenesisCovenantGroupArrayT = obj.unchecked_ref();
         let result = Vec::<CoreGenesisCovenantGroup>::try_from(typed);
         assert!(result.is_err());
+    }
+
+    // -------------------------------------
+    // CovenantBinding tests
+
+    #[wasm_bindgen_test]
+    fn test_covenant_binding_construction() {
+        let covenant_id = Hash::from_bytes([0xab; HASH_SIZE]);
+        let binding = CovenantBinding::new(0, covenant_id);
+
+        assert_eq!(binding.get_authorizing_input(), 0);
+        assert_eq!(binding.get_covenant_id(), covenant_id);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_covenant_binding_construction_plain() {
+        let covenant_id = Hash::from_bytes([0xab; HASH_SIZE]);
+
+        let obj = Object::new();
+        obj.set("authorizingInput", &JsValue::from(0)).expect("set authorizingInput");
+        obj.set("covenantId", &JsValue::from_str(&covenant_id.to_string())).expect("set covenantId");
+
+        let binding = CovenantBinding::try_owned_from(obj).expect("try_cast_from failed");
+
+        assert_eq!(binding.get_authorizing_input(), 0);
+        assert_eq!(binding.get_covenant_id(), covenant_id);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_covenant_binding_to_json() {
+        let covenant_id_in = Hash::from_bytes([0xab; HASH_SIZE]);
+        let binding = CovenantBinding::new(0, covenant_id_in);
+
+        let obj = binding.to_js_object().expect("to_js_object failed");
+
+        let authorizing_input_out = obj.get_u16("authorizingInput").expect("failed to get authorizingInput");
+        let covenant_id_out =
+            Hash::from_str(&obj.get_string("covenantId").expect("failed to get covenantId")).expect("failed to create Hash from str");
+
+        assert_eq!(0, authorizing_input_out);
+        assert_eq!(covenant_id_in, covenant_id_out);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_covenant_binding_set_authorizing_input() {
+        let covenant_id = Hash::from_bytes([0xab; HASH_SIZE]);
+        let mut binding = CovenantBinding::new(0, covenant_id);
+
+        let new_input = 1;
+
+        binding.set_authorizing_input(new_input);
+
+        assert_eq!(binding.get_authorizing_input(), new_input);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_covenant_binding_set_covenant_id() {
+        let covenant_id = Hash::from_bytes([0xab; HASH_SIZE]);
+        let mut binding = CovenantBinding::new(0, covenant_id);
+
+        let new_covenant_id = Hash::from_bytes([0xac; HASH_SIZE]);
+
+        binding.set_covenant_id(new_covenant_id);
+
+        assert_eq!(binding.get_covenant_id(), new_covenant_id);
     }
 }

--- a/consensus/client/src/covenant.rs
+++ b/consensus/client/src/covenant.rs
@@ -225,7 +225,7 @@ impl TryCastFromJs for GenesisCovenantGroup {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
     use super::*;
     use kaspa_hashes::HASH_SIZE;
@@ -233,8 +233,11 @@ mod tests {
     use wasm_bindgen::JsValue;
     use wasm_bindgen_test::wasm_bindgen_test;
 
-    /// Helper - convert &[u32] to a JS Array
-    fn _to_js_array(values: &[u32]) -> js_sys::Array {
+    // -------------------------------------
+    // GenesisCovenantGroup tests
+
+    // Helper - convert &[u32] to a JS Array
+    fn to_js_array(values: &[u32]) -> js_sys::Array {
         let arr = js_sys::Array::new();
         for &v in values {
             arr.push(&JsValue::from(v));
@@ -242,52 +245,52 @@ mod tests {
         arr
     }
 
-    /// Helper - construct GenesisCovenantGroup via WASM constructor
-    fn _construct_covenant_group(authorizing_input: u16, outputs: &[u32]) -> GenesisCovenantGroup {
-        GenesisCovenantGroup::ctor(authorizing_input, _to_js_array(outputs).unchecked_into()).expect("constructor should succeed")
+    // Helper - construct GenesisCovenantGroup via WASM constructor
+    fn construct_genesis_covenant_group(authorizing_input: u16, outputs: &[u32]) -> GenesisCovenantGroup {
+        GenesisCovenantGroup::ctor(authorizing_input, to_js_array(outputs).unchecked_into()).expect("constructor should succeed")
     }
 
-    /// Helper - build plain GenesisCovenantGroup JS object
-    fn _construct_covenant_group_plain(authorizing_input: u16, outputs: &[u32]) -> JsValue {
+    // Helper - build plain GenesisCovenantGroup JS object
+    fn construct_genesis_covenant_group_plain(authorizing_input: u16, outputs: &[u32]) -> JsValue {
         let obj = Object::new();
         obj.set("authorizingInput", &JsValue::from(authorizing_input)).expect("set authorizingInput");
-        obj.set("outputs", &_to_js_array(outputs).into()).expect("set outputs");
+        obj.set("outputs", &to_js_array(outputs).into()).expect("set outputs");
         obj.into()
     }
 
-    /// Helper - get outputs field
-    fn _get_outputs(group: &GenesisCovenantGroup) -> Vec<u32> {
+    // Helper - get outputs field
+    fn get_genesis_covenant_group_outputs(group: &GenesisCovenantGroup) -> Vec<u32> {
         serde_wasm_bindgen::from_value(group.outputs().into()).expect("outputs should deserialize")
     }
 
     #[wasm_bindgen_test]
-    fn _test_genesis_covenant_group_construction() {
-        let group = _construct_covenant_group(1, &[0, 1, 2]);
+    fn test_genesis_covenant_group_construction() {
+        let group = construct_genesis_covenant_group(1, &[0, 1, 2]);
 
         assert_eq!(group.authorizing_input(), 1);
-        assert_eq!(_get_outputs(&group), vec![0, 1, 2]);
+        assert_eq!(get_genesis_covenant_group_outputs(&group), vec![0, 1, 2]);
     }
 
     #[wasm_bindgen_test]
-    fn _test_authorizing_input_setter() {
-        let mut group = _construct_covenant_group(0, &[0, 1]);
+    fn test_genesis_covenant_group_authorizing_input_setter() {
+        let mut group = construct_genesis_covenant_group(0, &[0, 1]);
 
         group.set_authorizing_input(7);
         assert_eq!(group.authorizing_input(), 7);
     }
 
     #[wasm_bindgen_test]
-    fn _test_outputs_setter() {
-        let mut group = _construct_covenant_group(0, &[0, 1]);
+    fn test_genesis_covenant_group_outputs_setter() {
+        let mut group = construct_genesis_covenant_group(0, &[0, 1]);
 
-        group.set_outputs(_to_js_array(&[3, 4, 5]).unchecked_into()).expect("set_outputs should succeed");
+        group.set_outputs(to_js_array(&[3, 4, 5]).unchecked_into()).expect("set_outputs should succeed");
 
-        assert_eq!(_get_outputs(&group), vec![3, 4, 5]);
+        assert_eq!(get_genesis_covenant_group_outputs(&group), vec![3, 4, 5]);
     }
 
     #[wasm_bindgen_test]
-    fn _test_to_json() {
-        let group = _construct_covenant_group(2, &[0, 1]);
+    fn test_genesis_covenant_group_to_json() {
+        let group = construct_genesis_covenant_group(2, &[0, 1]);
 
         let obj = group.to_js_object().expect("to_js_object should succeed");
         let auth_input = js_sys::Reflect::get(&obj, &JsValue::from_str("authorizingInput")).expect("should have authorizingInput");
@@ -307,24 +310,18 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_try_cast_from_plain_object() {
-        let js_val = _construct_covenant_group_plain(1, &[0, 2]);
+    fn test_genesis_covenant_group_try_cast_from_plain_object() {
+        let js_val = construct_genesis_covenant_group_plain(1, &[0, 2]);
         let group = GenesisCovenantGroup::try_owned_from(&js_val).expect("try_cast_from should succeed");
         assert_eq!(group.inner().authorizing_input, 1);
         assert_eq!(group.inner().outputs, vec![0, 2]);
     }
 
     #[wasm_bindgen_test]
-    fn _test_empty_outputs_construction() {
-        let group = _construct_covenant_group(0, &[]);
-        assert!(_get_outputs(&group).is_empty());
-    }
-
-    #[wasm_bindgen_test]
-    fn _test_array_t_from_plain_objects() {
+    fn test_genesis_covenant_group_array_t_from_plain_objects() {
         let arr = js_sys::Array::new();
-        arr.push(&_construct_covenant_group_plain(0, &[0, 1]));
-        arr.push(&_construct_covenant_group_plain(1, &[2, 3, 4]));
+        arr.push(&construct_genesis_covenant_group_plain(0, &[0, 1]));
+        arr.push(&construct_genesis_covenant_group_plain(1, &[2, 3, 4]));
 
         let typed_arr: &GenesisCovenantGroupArrayT = arr.unchecked_ref();
         let groups: Vec<CoreGenesisCovenantGroup> = Vec::try_from(typed_arr).expect("should convert from plain objects");
@@ -337,9 +334,9 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_array_t_from_wasm_instances() {
-        let g0 = _construct_covenant_group(5, &[10, 11]);
-        let g1 = _construct_covenant_group(6, &[20]);
+    fn test_genesis_covenant_group_array_t_from_wasm_instances() {
+        let g0 = construct_genesis_covenant_group(5, &[10, 11]);
+        let g1 = construct_genesis_covenant_group(6, &[20]);
 
         let arr = js_sys::Array::new();
         arr.push(&JsValue::from(g0));
@@ -353,43 +350,6 @@ mod tests {
         assert_eq!(groups[0].outputs, vec![10, 11]);
         assert_eq!(groups[1].authorizing_input, 6);
         assert_eq!(groups[1].outputs, vec![20]);
-    }
-
-    #[wasm_bindgen_test]
-    fn _test_ctor_rejects_invalid_outputs() {
-        let result = GenesisCovenantGroup::ctor(0, JsValue::from_str("not an array").unchecked_into());
-        assert!(result.is_err());
-    }
-
-    #[wasm_bindgen_test]
-    fn _test_set_outputs_rejects_invalid_value() {
-        let mut group = _construct_covenant_group(0, &[0, 1]);
-        let result = group.set_outputs(JsValue::from_str("bad").unchecked_into());
-        assert!(result.is_err());
-    }
-
-    #[wasm_bindgen_test]
-    fn _test_try_cast_rejects_non_object() {
-        let val = JsValue::from(42);
-        let result = GenesisCovenantGroup::try_owned_from(&val);
-        assert!(result.is_err());
-    }
-
-    #[wasm_bindgen_test]
-    fn _test_try_cast_rejects_missing_fields() {
-        let obj = Object::new();
-        obj.set("outputs", &_to_js_array(&[0, 1]).into()).expect("set outputs");
-        let js_val: JsValue = obj.into();
-        let result = GenesisCovenantGroup::try_owned_from(&js_val);
-        assert!(result.is_err());
-    }
-
-    #[wasm_bindgen_test]
-    fn _test_array_t_rejects_non_array() {
-        let obj = Object::new();
-        let typed: &GenesisCovenantGroupArrayT = obj.unchecked_ref();
-        let result = Vec::<CoreGenesisCovenantGroup>::try_from(typed);
-        assert!(result.is_err());
     }
 
     // -------------------------------------
@@ -434,7 +394,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_covenant_binding_set_authorizing_input() {
+    fn test_covenant_binding_authorizing_input_setter() {
         let covenant_id = Hash::from_bytes([0xab; HASH_SIZE]);
         let mut binding = CovenantBinding::new(0, covenant_id);
 
@@ -446,7 +406,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_covenant_binding_set_covenant_id() {
+    fn test_covenant_binding_covenant_id_setter() {
         let covenant_id = Hash::from_bytes([0xab; HASH_SIZE]);
         let mut binding = CovenantBinding::new(0, covenant_id);
 

--- a/consensus/client/src/hash.rs
+++ b/consensus/client/src/hash.rs
@@ -111,7 +111,7 @@ pub fn js_covenant_id(genesis_outpoint: &TransactionOutpointT, auth_outputs: &Co
     Ok(covenant_id::covenant_id(outpoint, outputs.iter().map(|(i, o)| (*i, o))))
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
     use super::*;
     use crate::output::TransactionOutput;
@@ -121,12 +121,12 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     // Helper - construct ScriptPublicKey
-    fn _construct_spk() -> ScriptPublicKey {
+    fn construct_spk() -> ScriptPublicKey {
         ScriptPublicKey::new(0, vec![0xaa, 0xbb].into())
     }
 
     // Helper - construct plain TransactionOutpoint JS object
-    fn _construct_outpoint_obj(index: u32) -> Object {
+    fn construct_outpoint_obj(index: u32) -> Object {
         let txid_hex = format!("{}", TransactionId::from_slice(&[0xab; 32]));
         let obj = Object::new();
         obj.set("transactionId", &JsValue::from_str(&txid_hex)).unwrap();
@@ -135,7 +135,7 @@ mod tests {
     }
 
     // Helper - construct ICovenantAuthorizedOutput JS object
-    fn _construct_auth_output_obj(index: u32, value: u64, spk: &ScriptPublicKey) -> JsValue {
+    fn construct_auth_output_obj(index: u32, value: u64, spk: &ScriptPublicKey) -> JsValue {
         let obj = Object::new();
         obj.set("index", &JsValue::from(index)).unwrap();
         let output = TransactionOutput::ctor(value, spk, None);
@@ -144,7 +144,7 @@ mod tests {
     }
 
     // Helper - construct ICovenantAuthorizedOutput[] JS array
-    fn _construct_auth_outputs_array(entries: &[(u32, u64)]) -> js_sys::Array {
+    fn construct_auth_outputs_array(entries: &[(u32, u64)]) -> js_sys::Array {
         let spk = _construct_spk();
         let arr = js_sys::Array::new();
         for &(index, value) in entries {
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_covenant_id_matches_core() {
+    fn test_covenant_id_matches_core() {
         let spk = _construct_spk();
         let entries: &[(u32, u64)] = &[(0, 1000), (1, 2000)];
 
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_covenant_id_rejects_non_object_in_array() {
+    fn test_covenant_id_rejects_non_object_in_array() {
         let outpoint = _construct_outpoint_obj(0);
         let arr = js_sys::Array::new();
         arr.push(&JsValue::from(42));
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_covenant_id_rejects_missing_fields() {
+    fn test_covenant_id_rejects_missing_fields() {
         let outpoint = _construct_outpoint_obj(0);
         let arr = js_sys::Array::new();
         let obj = Object::new();

--- a/consensus/client/src/hash.rs
+++ b/consensus/client/src/hash.rs
@@ -145,22 +145,22 @@ mod tests {
 
     // Helper - construct ICovenantAuthorizedOutput[] JS array
     fn construct_auth_outputs_array(entries: &[(u32, u64)]) -> js_sys::Array {
-        let spk = _construct_spk();
+        let spk = construct_spk();
         let arr = js_sys::Array::new();
         for &(index, value) in entries {
-            arr.push(&_construct_auth_output_obj(index, value, &spk));
+            arr.push(&construct_auth_output_obj(index, value, &spk));
         }
         arr
     }
 
     #[wasm_bindgen_test]
     fn test_covenant_id_matches_core() {
-        let spk = _construct_spk();
+        let spk = construct_spk();
         let entries: &[(u32, u64)] = &[(0, 1000), (1, 2000)];
 
         // WASM covenant id
-        let outpoint_js = _construct_outpoint_obj(5);
-        let auth_array = _construct_auth_outputs_array(entries);
+        let outpoint_js = construct_outpoint_obj(5);
+        let auth_array = construct_auth_outputs_array(entries);
         let wasm_hash = js_covenant_id(outpoint_js.unchecked_ref(), auth_array.unchecked_ref()).expect("wasm call should succeed");
 
         // Core covenant id
@@ -174,7 +174,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_covenant_id_rejects_non_object_in_array() {
-        let outpoint = _construct_outpoint_obj(0);
+        let outpoint = construct_outpoint_obj(0);
         let arr = js_sys::Array::new();
         arr.push(&JsValue::from(42));
         let result = js_covenant_id(outpoint.unchecked_ref(), arr.unchecked_ref());
@@ -183,7 +183,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_covenant_id_rejects_missing_fields() {
-        let outpoint = _construct_outpoint_obj(0);
+        let outpoint = construct_outpoint_obj(0);
         let arr = js_sys::Array::new();
         let obj = Object::new();
         obj.set("index", &JsValue::from(0)).unwrap();

--- a/consensus/client/src/output.rs
+++ b/consensus/client/src/output.rs
@@ -4,6 +4,7 @@
 
 #![allow(non_snake_case)]
 
+use crate::covenant::CovenantBinding as ClientCovenantBinding;
 use crate::imports::*;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -88,8 +89,14 @@ impl TransactionOutput {
 impl TransactionOutput {
     #[wasm_bindgen(constructor)]
     /// TransactionOutput constructor
-    pub fn ctor(value: u64, script_public_key: &ScriptPublicKey, covenant: Option<cctx::CovenantBinding>) -> TransactionOutput {
-        Self { inner: Arc::new(Mutex::new(TransactionOutputInner { value, script_public_key: script_public_key.clone(), covenant })) }
+    pub fn ctor(value: u64, script_public_key: &ScriptPublicKey, covenant: Option<ClientCovenantBinding>) -> TransactionOutput {
+        Self {
+            inner: Arc::new(Mutex::new(TransactionOutputInner {
+                value,
+                script_public_key: script_public_key.clone(),
+                covenant: covenant.map(cctx::CovenantBinding::from),
+            })),
+        }
     }
 
     #[wasm_bindgen(getter, js_name = value)]
@@ -113,13 +120,13 @@ impl TransactionOutput {
     }
 
     #[wasm_bindgen(getter, js_name = covenant)]
-    pub fn get_covenant(&self) -> Option<cctx::CovenantBinding> {
-        self.inner().covenant
+    pub fn get_covenant(&self) -> Option<ClientCovenantBinding> {
+        self.inner().covenant.map(ClientCovenantBinding::from)
     }
 
     #[wasm_bindgen(setter, js_name = covenant)]
-    pub fn set_covenant(&self, v: cctx::CovenantBinding) {
-        self.inner().covenant = Some(v)
+    pub fn set_covenant(&self, v: ClientCovenantBinding) {
+        self.inner().covenant = Some(v.into())
     }
 }
 
@@ -158,11 +165,11 @@ impl TryCastFromJs for TransactionOutput {
             if let Some(object) = Object::try_from(value.as_ref()) {
                 let value = object.get_u64("value")?;
                 let script_public_key = ScriptPublicKey::try_owned_from(object.get_value("scriptPublicKey")?)?;
-                let covenant = object
+                let covenant: Option<ClientCovenantBinding> = object
                     .try_get_value("covenant")?
                     .map(|v| v.try_into_owned().map_err(|err| Error::convert("covenant", err)))
                     .transpose()?;
-                Ok(TransactionOutput::new(value, script_public_key, covenant).into())
+                Ok(TransactionOutput::new(value, script_public_key, covenant.map(cctx::CovenantBinding::from)).into())
             } else {
                 Err("TransactionInput must be an object".into())
             }

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -580,13 +580,13 @@ mod tests {
         let cov2 = inner.outputs[2].get_covenant().unwrap();
         let cov3 = inner.outputs[3].get_covenant().unwrap();
 
-        assert_eq!(cov0.authorizing_input, 0);
-        assert_eq!(cov1.authorizing_input, 0);
-        assert_eq!(cov2.authorizing_input, 1);
-        assert_eq!(cov3.authorizing_input, 1);
-        assert_eq!(cov0.covenant_id, cov1.covenant_id);
-        assert_eq!(cov2.covenant_id, cov3.covenant_id);
-        assert_ne!(cov0.covenant_id, cov2.covenant_id);
+        assert_eq!(cov0.get_authorizing_input(), 0);
+        assert_eq!(cov1.get_authorizing_input(), 0);
+        assert_eq!(cov2.get_authorizing_input(), 1);
+        assert_eq!(cov3.get_authorizing_input(), 1);
+        assert_eq!(cov0.get_covenant_id(), cov1.get_covenant_id());
+        assert_eq!(cov2.get_covenant_id(), cov3.get_covenant_id());
+        assert_ne!(cov0.get_covenant_id(), cov2.get_covenant_id());
     }
 
     #[wasm_bindgen_test]

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -518,7 +518,7 @@ impl Transaction {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
     use super::*;
     use crate::input::TransactionInput;
@@ -530,12 +530,12 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     // Helper - construct ScriptPublicKey
-    fn _construct_spk() -> ScriptPublicKey {
+    fn construct_spk() -> ScriptPublicKey {
         ScriptPublicKey::new(0, vec![0xaa, 0xbb].into())
     }
 
     // Helper - construct Transaction with given number of inputs and outputs
-    fn _construct_tx(num_inputs: u32, num_outputs: u32) -> Transaction {
+    fn construct_tx(num_inputs: u32, num_outputs: u32) -> Transaction {
         let fixed_txid = TransactionId::from_slice(&[0u8; 32]);
         let spk = _construct_spk();
 
@@ -553,7 +553,7 @@ mod tests {
     }
 
     // Helper - construct GenesisCovenantGroup[] JS array
-    fn _construct_groups_array(groups: &[(u16, &[u32])]) -> js_sys::Array {
+    fn construct_groups_array(groups: &[(u16, &[u32])]) -> js_sys::Array {
         let arr = js_sys::Array::new();
         for &(auth_input, outputs) in groups {
             let obj = Object::new();
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_populate_multiple_groups() {
+    fn test_populate_multiple_groups() {
         let tx = _construct_tx(2, 4);
         let groups = _construct_groups_array(&[(0, &[0, 1]), (1, &[2, 3])]);
         tx.js_populate_genesis_covenants(groups.unchecked_ref()).expect("populate should succeed");
@@ -590,7 +590,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn _test_outputs_preserve_value_and_spk() {
+    fn test_outputs_preserve_value_and_spk() {
         let spk = _construct_spk();
         let tx = _construct_tx(1, 2);
         let groups = _construct_groups_array(&[(0, &[0, 1])]);

--- a/consensus/client/src/transaction.rs
+++ b/consensus/client/src/transaction.rs
@@ -537,7 +537,7 @@ mod tests {
     // Helper - construct Transaction with given number of inputs and outputs
     fn construct_tx(num_inputs: u32, num_outputs: u32) -> Transaction {
         let fixed_txid = TransactionId::from_slice(&[0u8; 32]);
-        let spk = _construct_spk();
+        let spk = construct_spk();
 
         let inputs: Vec<TransactionInput> = (0..num_inputs)
             .map(|i| {
@@ -570,8 +570,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_populate_multiple_groups() {
-        let tx = _construct_tx(2, 4);
-        let groups = _construct_groups_array(&[(0, &[0, 1]), (1, &[2, 3])]);
+        let tx = construct_tx(2, 4);
+        let groups = construct_groups_array(&[(0, &[0, 1]), (1, &[2, 3])]);
         tx.js_populate_genesis_covenants(groups.unchecked_ref()).expect("populate should succeed");
 
         let inner = tx.inner();
@@ -591,9 +591,9 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_outputs_preserve_value_and_spk() {
-        let spk = _construct_spk();
-        let tx = _construct_tx(1, 2);
-        let groups = _construct_groups_array(&[(0, &[0, 1])]);
+        let spk = construct_spk();
+        let tx = construct_tx(1, 2);
+        let groups = construct_groups_array(&[(0, &[0, 1])]);
         tx.js_populate_genesis_covenants(groups.unchecked_ref()).expect("populate should succeed");
 
         let inner = tx.inner();

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -15,7 +15,6 @@ use crate::{
     subnets::{self, SubnetworkId},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
-use js_sys::Object;
 use kaspa_utils::hex::ToHex;
 use kaspa_utils::mem_size::MemSizeEstimator;
 use kaspa_utils::{serde_bytes, serde_bytes_fixed_ref};
@@ -33,9 +32,6 @@ use std::{
     str::{self},
 };
 use wasm_bindgen::prelude::*;
-use workflow_wasm::convert::{Cast, TryCastFromJs, TryCastJsInto};
-use workflow_wasm::extensions::ObjectExtension;
-use workflow_wasm::prelude::CastFromJs;
 
 use crate::hashing::tx::seq_commit_tx_digest;
 use kaspa_hashes::Hash;
@@ -150,65 +146,65 @@ impl TransactionOutput {
 }
 
 /// Binds a transaction output to the covenant and input authorizing its creation.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Copy, CastFromJs)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Copy)]
 #[serde(rename_all = "camelCase")]
-#[wasm_bindgen(inspectable)]
+// #[wasm_bindgen(inspectable)]
 pub struct CovenantBinding {
     pub authorizing_input: u16,
     pub covenant_id: Hash,
 }
-type CastErr = workflow_wasm::error::Error;
-impl TryCastFromJs for CovenantBinding {
-    type Error = CastErr;
+// type CastErr = workflow_wasm::error::Error;
+// impl TryCastFromJs for CovenantBinding {
+//     type Error = CastErr;
 
-    fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
-    where
-        R: AsRef<JsValue> + 'a,
-    {
-        Self::resolve(value, || {
-            let Some(object) = Object::try_from(value.as_ref()) else { return Err(CastErr::NotAnObject) };
-            let value = object.get_u16("authorizing_input")?;
-            let covenant_id = object.get_value("covenant_id")?.try_into_owned()?;
-            Ok(Self { authorizing_input: value, covenant_id })
-        })
-    }
-}
+//     fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
+//     where
+//         R: AsRef<JsValue> + 'a,
+//     {
+//         Self::resolve(value, || {
+//             let Some(object) = Object::try_from(value.as_ref()) else { return Err(CastErr::NotAnObject) };
+//             let value = object.get_u16("authorizing_input")?;
+//             let covenant_id = object.get_value("covenant_id")?.try_into_owned()?;
+//             Ok(Self { authorizing_input: value, covenant_id })
+//         })
+//     }
+// }
 
-#[wasm_bindgen]
+// #[wasm_bindgen]
 impl CovenantBinding {
-    #[wasm_bindgen(constructor)]
     pub fn new(authorizing_input: u16, covenant_id: Hash) -> Self {
         Self { authorizing_input, covenant_id }
     }
-
-    #[wasm_bindgen(setter, js_name = authorizingInput)]
-    pub fn set_authorizing_input(&mut self, v: u16) {
-        self.authorizing_input = v;
-    }
-
-    #[wasm_bindgen(getter, js_name = authorizingInput)]
-    pub fn get_authorizing_input(&self) -> u16 {
-        self.authorizing_input
-    }
-
-    #[wasm_bindgen(setter, js_name = covenantId)]
-    pub fn set_covenant_id(&mut self, v: Hash) {
-        self.covenant_id = v;
-    }
-
-    #[wasm_bindgen(getter, js_name = covenantId)]
-    pub fn get_covenant_id(&self) -> Hash {
-        self.covenant_id
-    }
-
-    #[wasm_bindgen(js_name = "toJSON")]
-    pub fn to_js_object(&self) -> Result<Object, CastErr> {
-        let obj = Object::new();
-        obj.set("authorizingInput", &self.authorizing_input.into())?;
-        obj.set("covenantId", &self.covenant_id.to_string().into())?;
-        Ok(obj)
-    }
 }
+
+//     #[wasm_bindgen(setter, js_name = authorizingInput)]
+//     pub fn set_authorizing_input(&mut self, v: u16) {
+//         self.authorizing_input = v;
+//     }
+
+//     #[wasm_bindgen(getter, js_name = authorizingInput)]
+//     pub fn get_authorizing_input(&self) -> u16 {
+//         self.authorizing_input
+//     }
+
+//     #[wasm_bindgen(setter, js_name = covenantId)]
+//     pub fn set_covenant_id(&mut self, v: Hash) {
+//         self.covenant_id = v;
+//     }
+
+//     #[wasm_bindgen(getter, js_name = covenantId)]
+//     pub fn get_covenant_id(&self) -> Hash {
+//         self.covenant_id
+//     }
+
+//     #[wasm_bindgen(js_name = "toJSON")]
+//     pub fn to_js_object(&self) -> Result<Object, CastErr> {
+//         let obj = Object::new();
+//         obj.set("authorizingInput", &self.authorizing_input.into())?;
+//         obj.set("covenantId", &self.covenant_id.to_string().into())?;
+//         Ok(obj)
+//     }
+// }
 
 /// A genesis covenant group for bulk covenant binding population.
 ///

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -148,27 +148,10 @@ impl TransactionOutput {
 /// Binds a transaction output to the covenant and input authorizing its creation.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Copy)]
 #[serde(rename_all = "camelCase")]
-// #[wasm_bindgen(inspectable)]
 pub struct CovenantBinding {
     pub authorizing_input: u16,
     pub covenant_id: Hash,
 }
-// type CastErr = workflow_wasm::error::Error;
-// impl TryCastFromJs for CovenantBinding {
-//     type Error = CastErr;
-
-//     fn try_cast_from<'a, R>(value: &'a R) -> Result<Cast<'a, Self>, Self::Error>
-//     where
-//         R: AsRef<JsValue> + 'a,
-//     {
-//         Self::resolve(value, || {
-//             let Some(object) = Object::try_from(value.as_ref()) else { return Err(CastErr::NotAnObject) };
-//             let value = object.get_u16("authorizing_input")?;
-//             let covenant_id = object.get_value("covenant_id")?.try_into_owned()?;
-//             Ok(Self { authorizing_input: value, covenant_id })
-//         })
-//     }
-// }
 
 // #[wasm_bindgen]
 impl CovenantBinding {
@@ -176,35 +159,6 @@ impl CovenantBinding {
         Self { authorizing_input, covenant_id }
     }
 }
-
-//     #[wasm_bindgen(setter, js_name = authorizingInput)]
-//     pub fn set_authorizing_input(&mut self, v: u16) {
-//         self.authorizing_input = v;
-//     }
-
-//     #[wasm_bindgen(getter, js_name = authorizingInput)]
-//     pub fn get_authorizing_input(&self) -> u16 {
-//         self.authorizing_input
-//     }
-
-//     #[wasm_bindgen(setter, js_name = covenantId)]
-//     pub fn set_covenant_id(&mut self, v: Hash) {
-//         self.covenant_id = v;
-//     }
-
-//     #[wasm_bindgen(getter, js_name = covenantId)]
-//     pub fn get_covenant_id(&self) -> Hash {
-//         self.covenant_id
-//     }
-
-//     #[wasm_bindgen(js_name = "toJSON")]
-//     pub fn to_js_object(&self) -> Result<Object, CastErr> {
-//         let obj = Object::new();
-//         obj.set("authorizingInput", &self.authorizing_input.into())?;
-//         obj.set("covenantId", &self.covenant_id.to_string().into())?;
-//         Ok(obj)
-//     }
-// }
 
 /// A genesis covenant group for bulk covenant binding population.
 ///

--- a/wallet/core/src/tx/payment.rs
+++ b/wallet/core/src/tx/payment.rs
@@ -3,7 +3,7 @@
 //!
 
 use crate::imports::*;
-use kaspa_consensus_client::{TransactionOutput, TransactionOutputInner};
+use kaspa_consensus_client::{CovenantBinding as ClientCovenantBinding, TransactionOutput, TransactionOutputInner};
 use kaspa_consensus_core::tx::CovenantBinding;
 use kaspa_txscript::pay_to_address_script;
 
@@ -69,7 +69,7 @@ pub struct PaymentOutput {
     #[wasm_bindgen(getter_with_clone)]
     pub address: Address,
     pub amount: u64,
-    pub covenant: Option<CovenantBinding>,
+    pub covenant: Option<ClientCovenantBinding>,
 }
 
 impl TryCastFromJs for PaymentOutput {
@@ -115,7 +115,7 @@ impl PaymentOutput {
 
     /// Factory method for covenant variant
     #[wasm_bindgen(js_name = withCovenant)]
-    pub fn with_covenant(address: Address, amount: u64, covenant: CovenantBinding) -> Self {
+    pub fn with_covenant(address: Address, amount: u64, covenant: ClientCovenantBinding) -> Self {
         Self { address, amount, covenant: Some(covenant) }
     }
 }
@@ -125,7 +125,7 @@ impl From<PaymentOutput> for TransactionOutput {
         Self::new_with_inner(TransactionOutputInner {
             script_public_key: pay_to_address_script(&value.address),
             value: value.amount,
-            covenant: value.covenant,
+            covenant: value.covenant.map(CovenantBinding::from),
         })
     }
 }


### PR DESCRIPTION
**Summary of changes:**
- Move `CovenantBinding` WASM glue from `consensus/core/src/tx.rs` to `consensus/client/src/covenant.rs`. This required changing `PaymentOutput`'s field `covenant` from consensus core's to client's `CovenantBinding` in order to expose to WASM (in `wallet/core/src/tx/payment.rs`).
- Gate all WASM tests via `#[cfg(all(test, target_arch = "wasm32"))]` and remove leading underscore from test names
- Remove `GenesisCovenantGroup` rejection tests
- Some other test clean up (function names, comments, etc.)